### PR TITLE
refactor: move main pages to cms

### DIFF
--- a/src/data/en-gb.i18n.ts
+++ b/src/data/en-gb.i18n.ts
@@ -5,27 +5,6 @@ const trans: Record<string, any> = {
 		projects: 'Projects',
 		tools: 'Tools',
 	},
-	page: {
-		home: {
-			title: 'Dan Gibbs',
-			description: 'The homepage of Dan Gibbs',
-		},
-		blog: {
-			title: 'Blog',
-			description: 'Web and techology related posts from Dan Gibbs',
-		},
-		projects: {
-			title: 'Projects',
-			description: 'A list of current projects',
-			heading: 'Projects',
-		},
-		tools: {
-			title: 'Tools',
-			description: 'Web based tools and utilities',
-			heading: 'Tools & Utilities',
-			text: 'An assortment of web based tools and utilities.',
-		},
-	},
 	component: {
 		copyright: `Copyright $1 2007 - $2 Dan Gibbs`,
 		build: 'Build',

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,22 +1,23 @@
 ---
-import { __ } from '@i18n/utils';
 import BaseLayout from '@layouts/Base.astro';
 import Logo from '@components/Block/LogoIcon.astro';
 import Card from '@components/Block/Card.astro';
 import { env } from '@src/env.config';
-import { getAllPosts } from '@src/prismic';
 import { DateTime } from 'luxon';
+import { getPageByUID, getAllPosts } from '@src/prismic';
+import { generateFrontmatter } from '@utils/frontmatter';
+import SliceLibrary from '@components/Prismic/SliceLibrary.astro';
 
-const frontmatter = {
-	title: __('page.blog.title'),
-	description: __('page.blog.description'),
-	date: '2022-06-19',
-};
+const page = await getPageByUID('blog', 'page');
+const frontmatter = generateFrontmatter(page, 'Table');
+
 const posts = await getAllPosts().then((response) => response.results);
 const featured = posts.shift();
 ---
 
 <BaseLayout frontmatter={frontmatter} url={Astro.url}>
+	<SliceLibrary slices={page.data.slices} />
+
 	<article class="blog-featured">
 		<div class="blog-featured-logo">
 			<Logo size={92} icon={featured.tags[0]} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
-import { __ } from '@i18n/utils';
+import { getPageByUID } from '@src/prismic';
+import { generateFrontmatter } from '@utils/frontmatter';
 import BaseLayout from '@layouts/Base.astro';
 import { env } from '@src/env.config';
 import TechStack from '@components/Block/TechStack.astro';
@@ -7,11 +8,8 @@ import GithubActivityFeed from '@components/Block/GithubActivityFeed.astro';
 import Time from '@components/Block/Time.astro';
 import '@styles/icons.css';
 
-const frontmatter = {
-	title: __('page.home.title'),
-	description: __('page.home.description'),
-	date: '2026-02-23',
-};
+const page = await getPageByUID('index', 'page');
+const frontmatter = generateFrontmatter(page, 'Website');
 ---
 
 <BaseLayout frontmatter={frontmatter} url={Astro.url}>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,19 +1,18 @@
 ---
-import { __ } from '@i18n/utils';
 import BaseLayout from '@layouts/Base.astro';
 import Card from '@components/Block/Card.astro';
-import { getAllProjects } from '@src/prismic';
+import { getPageByUID, getAllProjects } from '@src/prismic';
+import { generateFrontmatter } from '@utils/frontmatter';
+import SliceLibrary from '@components/Prismic/SliceLibrary.astro';
+
+const page = await getPageByUID('projects', 'page');
+const frontmatter = generateFrontmatter(page, 'Table');
 
 const projects = await getAllProjects().then((response) => response.results);
-const frontmatter = {
-	title: __('page.projects.title'),
-	description: __('page.projects.description'),
-	date: '2026-02-23',
-};
 ---
 
 <BaseLayout frontmatter={frontmatter} url={Astro.url}>
-	<h1>{__('page.projects.heading')}</h1>
+	<SliceLibrary slices={page.data.slices} />
 
 	<section class="projects">
 		{

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -18,7 +18,7 @@ export const GET: APIRoute = async () => {
 		});
 	});
 
-	for (const type of ['project', 'blog', 'tools']) {
+	for (const type of ['page', 'project', 'blog', 'tools']) {
 		try {
 			const pages = await client.getAllByType(type, {
 				fetch: ['page.last_publication_date'],
@@ -31,7 +31,12 @@ export const GET: APIRoute = async () => {
 	}
 
 	sitemapRoutes.forEach((route) => {
-		const url = `${baseUrl.replace(/\/$/, '')}${route.url}`;
+		let url = `${baseUrl.replace(/\/$/, '')}`;
+
+		if (route.uid != 'index') {
+			url += route.url ? route.url : `/${route.uid}`;
+		}
+
 		const lastMod = route.last_publication_date
 			? new Date(route.last_publication_date).toISOString()
 			: new Date().toISOString();

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -1,20 +1,18 @@
 ---
-import { __ } from '@i18n/utils';
 import BaseLayout from '@layouts/Base.astro';
-import { getAllTools } from '@src/prismic';
 import { env } from '@src/env.config';
+import { getPageByUID, getAllTools } from '@src/prismic';
+import { generateFrontmatter } from '@utils/frontmatter';
+import SliceLibrary from '@components/Prismic/SliceLibrary.astro';
+
+const page = await getPageByUID('tools', 'page');
+const frontmatter = generateFrontmatter(page, 'Table');
 
 const tools = await getAllTools().then((response) => response.results);
-const frontmatter = {
-	title: __('page.tools.title'),
-	description: __('page.tools.description'),
-	date: '2026-02-23',
-};
 ---
 
 <BaseLayout frontmatter={frontmatter} url={Astro.url}>
-	<h1>{__('page.tools.heading')}</h1>
-	<p>{__('page.tools.text')}</p>
+	<SliceLibrary slices={page.data.slices} />
 
 	<ol class="tools">
 		{

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -38,7 +38,7 @@ export function generateFrontmatter(document: PrismicDocument, type?: string): F
 		description: document.data.meta_description,
 		linkdata: {
 			...linkData,
-			...JSON.parse(document.data.linkdata[0].text),
+			...JSON.parse(document.data?.linkdata[0]?.text || '{}'),
 		},
 	};
 


### PR DESCRIPTION
Move the main pages (homepage, blog, projects and tools) to Prismic and remove i18n strings.