### PR TITLE
refactor: style and general performance amends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /logs/
 /test-results
 /dist/
+/public/badges/
 /.docker/*
 !/.docker/
 !/.docker/.env.local

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,6 +7,7 @@ import { transformerCopyButton } from '@rehype-pretty/transformers';
 import markdownIntegration from '@astropub/md';
 import remarkFlexibleMarkers from 'remark-flexible-markers';
 import searchIndexIntegration from './integrations/search-index-integration';
+import buildBadgesIntegration from './integrations/build-badges-integration';
 
 const env: Record<string, string> = loadEnv(
 	process.env.NODE_ENV ?? 'production',
@@ -25,6 +26,7 @@ export default defineConfig({
 	integrations: [
 		markdownIntegration(),
 		searchIndexIntegration(),
+		buildBadgesIntegration(),
 		sentry({
 			project: 'dangibbsuk',
 			org: 'dan-gibbd',
@@ -100,6 +102,11 @@ export default defineConfig({
 				},
 			],
 		],
+	},
+	vite: {
+		define: {
+			__SENTRY_DEBUG__: false,
+		},
 	},
 	output: 'static',
 	server: {

--- a/integrations/build-badges-integration.ts
+++ b/integrations/build-badges-integration.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AstroIntegration } from 'astro';
+
+const badges = [
+	{
+		file: 'test-status.svg',
+		url: 'https://img.shields.io/github/actions/workflow/status/gibbs/gibbs.github.io/test.yml?label=Tests&style=flat-square',
+	},
+	{
+		file: 'deploy-status.svg',
+		url: 'https://img.shields.io/github/actions/workflow/status/gibbs/gibbs.github.io/deploy.yml?label=Release&style=flat-square',
+	},
+];
+
+export default function buildBadgesIntegration(): AstroIntegration {
+	return {
+		name: 'build-badges',
+		hooks: {
+			'astro:config:setup': async ({ config, logger }) => {
+				const badgesDir = path.join(fileURLToPath(config.publicDir), 'badges');
+
+				await fs.mkdir(badgesDir, { recursive: true });
+
+				await Promise.all(
+					badges.map(async (badge) => {
+						try {
+							const response = await fetch(badge.url);
+
+							if (!response.ok) {
+								throw new Error(`${response.status} ${response.statusText}`);
+							}
+
+							await fs.writeFile(path.join(badgesDir, badge.file), await response.text());
+						} catch (error: unknown) {
+							logger.warn(`Failed to get badge ${badge.file}: ${error}`);
+						}
+					}),
+				);
+			},
+		},
+	};
+}

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,9 +3,7 @@ import * as Sentry from '@sentry/astro';
 Sentry.init({
 	dsn: 'https://ec20d6c9cec161c60f8ae948dac14b6d@o4511127957929984.ingest.us.sentry.io/4511127961796608',
 	sendDefaultPii: true,
-	integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+	integrations: [Sentry.browserTracingIntegration()],
 	enableLogs: true,
 	tracesSampleRate: 1.0,
-	replaysSessionSampleRate: 0.1,
-	replaysOnErrorSampleRate: 1.0,
 });

--- a/src/components/Block/BuildStatus.astro
+++ b/src/components/Block/BuildStatus.astro
@@ -1,5 +1,6 @@
 ---
 import { __ } from '@i18n/utils';
+import { env } from '@src/env.config';
 
 const buildDate: string = new Date().toJSON().slice(0, 10).split('-').reverse().join('-');
 const buildTime: string = new Date().toISOString();
@@ -12,7 +13,7 @@ const buildTime: string = new Date().toISOString();
 	<div class="flex gap-xs">
 		<a href="https://github.com/gibbs/gibbs.github.io/actions/workflows/test.yml">
 			<img
-				src="https://img.shields.io/github/actions/workflow/status/gibbs/gibbs.github.io/test.yml?label=Tests&style=flat-square"
+				src={new URL('/badges/test-status.svg', env.BASE_URL).href}
 				alt="Tests status badge"
 				height="26"
 				width="117"
@@ -21,7 +22,7 @@ const buildTime: string = new Date().toISOString();
 		</a>
 		<a href="https://github.com/gibbs/gibbs.github.io/actions/workflows/deploy.yml">
 			<img
-				src="https://img.shields.io/github/actions/workflow/status/gibbs/gibbs.github.io/deploy.yml?label=Release&style=flat-square"
+				src={new URL('/badges/deploy-status.svg', env.BASE_URL).href}
 				alt="Deploy status badge"
 				height="26"
 				width="135"

--- a/src/components/Block/GithubLink.astro
+++ b/src/components/Block/GithubLink.astro
@@ -1,0 +1,44 @@
+---
+import { __ } from '@i18n/utils';
+---
+
+<a
+	class="github-link"
+	href="https://github.com/gibbs/"
+	target="_blank"
+	rel="noopener noreferrer"
+	aria-label={__('component.github.label')}
+>
+	<svg
+		width="32px"
+		height="32px"
+		viewBox="0 0 16 16"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<path
+			d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+		></path>
+	</svg>
+</a>
+
+<style>
+	.github-link {
+		position: relative;
+		display: flex;
+		align-items: center;
+		align-self: center;
+		color: var(--white);
+
+		& > svg {
+			fill: currentColor;
+			width: 32px;
+			height: 32px;
+		}
+
+		&:focus-visible {
+			outline: 3px solid var(--tertiary);
+			outline-offset: 4px;
+		}
+	}
+</style>

--- a/src/components/Block/SchemePreference.astro
+++ b/src/components/Block/SchemePreference.astro
@@ -1,7 +1,7 @@
 <button
 	type="button"
 	class="scheme-preference"
-	:class="{ 'active': active == true, 'animate': animate == true }"
+	:class="{ 'active': active == true }"
 	id="scheme-preference"
 	title="Toggle colour scheme"
 	aria-label="Toggle colour scheme"
@@ -13,22 +13,31 @@
 	@click="changeScheme"
 >
 	<svg
-		fill="#000000"
-		width="20px"
-		height="20px"
-		viewBox="0 0 32 32"
-		version="1.1"
+		x-show="!isDark"
+		width="32px"
+		height="32px"
+		viewBox="0 0 24 24"
 		xmlns="http://www.w3.org/2000/svg"
 		aria-hidden="true"
 	>
 		<path
-			d="M0 16q0 3.264 1.28 6.24t3.392 5.088 5.12 3.424 6.208 1.248q3.264 0 6.24-1.248t5.088-3.424 3.392-5.088 1.28-6.24-1.28-6.208-3.392-5.12-5.088-3.392-6.24-1.28q-3.264 0-6.208 1.28t-5.12 3.392-3.392 5.12-1.28 6.208zM4 16q0-3.264 1.6-6.016t4.384-4.352 6.016-1.632 6.016 1.632 4.384 4.352 1.6 6.016-1.6 6.048-4.384 4.352-6.016 1.6-6.016-1.6-4.384-4.352-1.6-6.048zM16 26.016q2.72 0 5.024-1.344t3.648-3.648 1.344-5.024-1.344-4.992-3.648-3.648-5.024-1.344v20z"
+			d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.106 17.834a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.166 7.106a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591z"
 		></path>
 	</svg>
 
-	<span class="scheme-preference-switch" aria-hidden="true">
-		<span class="scheme-preference-slider"></span>
-	</span>
+	<svg
+		x-show="isDark"
+		width="32px"
+		height="32px"
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<path
+			d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 008.998-5.998z"
+		></path>
+	</svg>
+
 	<span class="sr-only" x-text="buttonLabel"></span>
 </button>
 
@@ -39,7 +48,6 @@
 				key: 'sp',
 				scheme: 'dark',
 				active: false,
-				animate: false,
 
 				init() {
 					this.scheme = this.getCustomPreference();
@@ -62,7 +70,6 @@
 				changeScheme() {
 					const preference = this.getToggledPreference();
 
-					this.animate = true;
 					this.scheme = preference;
 					localStorage.setItem(this.key, preference);
 					document.documentElement.setAttribute('data-color-scheme', preference);
@@ -92,22 +99,10 @@
 </script>
 
 <style>
-	:root {
-		--switch-height: 38px;
-		--switch-padding: 4px;
-		--switch-width: calc((var(--switch-height) * 2 - var(--switch-padding) * 2));
-		--switch-thumb-height: calc(var(--switch-height) - (var(--switch-padding) * 2));
-		--switch-thumb-width: calc(var(--switch-thumb-height));
-		--switch-thumb-travel: calc(
-			var(--switch-width) - var(--switch-thumb-width) - (var(--switch-padding) * 2)
-		);
-	}
-
 	.scheme-preference {
 		position: relative;
 		display: flex;
 		flex-direction: row;
-		gap: var(--gap-sm);
 		align-items: center;
 		align-self: center;
 		background: none;
@@ -116,14 +111,16 @@
 		border-radius: 50%;
 		cursor: pointer;
 		opacity: 0;
-		transition: opacity ease-in calc(var(--transition-duration) * 2);
 		appearance: none;
+		transition: opacity ease-in var(--transition-duration);
+		width: 32px;
+		height: 32px;
 
 		& > svg {
 			color: var(--white);
 			fill: currentColor;
-			width: 20px;
-			height: 20px;
+			width: 32px;
+			height: 32px;
 			stroke-linecap: round;
 		}
 
@@ -133,64 +130,7 @@
 		}
 	}
 
-	.scheme-preference-switch {
-		position: relative;
-		display: none;
-		width: var(--switch-width);
-		height: var(--switch-height);
-		padding: var(--switch-padding);
-	}
-
-	.scheme-preference-slider {
-		position: relative;
-		display: inline-flex;
-		align-items: center;
-		cursor: pointer;
-		width: 100%;
-		height: 100%;
-		background-color: var(--surface-2);
-		border: var(--border-width) solid rgba(0, 0, 0, 0.6);
-		border-radius: var(--border-radius);
-		transition: none;
-	}
-
-	.scheme-preference-slider:after {
-		position: relative;
-		display: flex;
-		content: '';
-		height: var(--switch-thumb-height);
-		width: var(--switch-thumb-width);
-		background-color: var(--white);
-		border: var(--border-width) solid rgba(0, 0, 0, 0.6);
-		border-radius: var(--border-radius);
-		transition: none;
-	}
-
 	.scheme-preference.active {
 		opacity: 1;
-	}
-
-	.scheme-preference.animate {
-		.scheme-preference-slider {
-			transition: var(--transition-duration);
-		}
-
-		.scheme-preference-slider:after {
-			transition: var(--transition-duration);
-		}
-	}
-
-	.scheme-preference[aria-pressed='true'] .scheme-preference-slider {
-		background-color: var(--accent);
-	}
-
-	.scheme-preference[aria-pressed='true'] .scheme-preference-slider:after {
-		transform: translateX(var(--switch-thumb-travel));
-	}
-
-	@media (--vp-md) {
-		.scheme-preference-switch {
-			display: flex;
-		}
 	}
 </style>

--- a/src/components/Block/SearchBar.astro
+++ b/src/components/Block/SearchBar.astro
@@ -77,8 +77,6 @@ const {
 
 <script>
 	// @ts-nocheck
-	import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
-
 	document.addEventListener('alpine:init', () => {
 		window.Alpine.data('search', () => ({
 			client: /** @type {any} */ (null),
@@ -103,13 +101,21 @@ const {
 
 				if (!this.url || !this.key || !this.index) {
 					this.status = 'Search is currently unavailable.';
-
-					return;
 				}
+			},
+
+			async loadClient() {
+				if (this.client) {
+					return this.client;
+				}
+
+				const { instantMeiliSearch } = await import('@meilisearch/instant-meilisearch');
 
 				this.client = instantMeiliSearch(this.url, this.key, {
 					placeholderSearch: false,
 				}).searchClient;
+
+				return this.client;
 			},
 
 			resultId(index) {
@@ -127,13 +133,14 @@ const {
 					return;
 				}
 
-				if (!this.client) {
+				if (!this.url || !this.key || !this.index) {
 					this.status = 'Search is currently unavailable.';
 					return;
 				}
 
 				try {
-					const response = await this.client.search([
+					const client = await this.loadClient();
+					const response = await client.search([
 						{
 							indexName: this.index,
 							params: {

--- a/src/components/Block/Time.astro
+++ b/src/components/Block/Time.astro
@@ -18,12 +18,20 @@ const {
 >
 
 <script>
-	import { DateTime } from 'luxon';
+	const formats = {
+		TIME_24_WITH_SHORT_OFFSET: {
+			hour: 'numeric',
+			minute: '2-digit',
+			second: '2-digit',
+			hourCycle: 'h23',
+			timeZoneName: 'shortOffset',
+		},
+	};
 
 	document.addEventListener('alpine:init', () => {
 		Alpine.data('xtime', () => {
 			return {
-				date: DateTime.now(),
+				date: new Date(),
 				interval: 0,
 				format: 'TIME_24_WITH_SHORT_OFFSET',
 				timezone: 'Europe/London',
@@ -34,21 +42,24 @@ const {
 					this.timezone = this.$el.dataset.timezone || this.timezone;
 
 					if (!this.interval) {
-						this.date = DateTime.now().setZone(this.timezone);
+						this.date = new Date();
 						return;
 					}
 
 					setInterval(() => {
-						this.date = DateTime.now().setZone(this.timezone);
+						this.date = new Date();
 					}, this.interval);
 				},
 
 				getTime() {
-					return this.date.toLocaleString(DateTime[this.format]);
+					return new Intl.DateTimeFormat(undefined, {
+						...(formats[this.format] ?? formats.TIME_24_WITH_SHORT_OFFSET),
+						timeZone: this.timezone,
+					}).format(this.date);
 				},
 
 				getDatetime() {
-					return this.date.toISO();
+					return this.date.toISOString();
 				},
 			};
 		});

--- a/src/components/Block/__tests__/BuildStatus.spec.ts
+++ b/src/components/Block/__tests__/BuildStatus.spec.ts
@@ -1,7 +1,13 @@
 // @vitest-environment happy-dom
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import BuildStatus from '../BuildStatus.astro';
+
+vi.mock('astro:env/client', () => {
+	return {
+		BASE_URL: 'http://localhost/',
+	};
+});
 
 describe('BuildStatus component', () => {
 	test('renders element', async () => {
@@ -10,5 +16,14 @@ describe('BuildStatus component', () => {
 
 		expect(result).toContain('<x-build-status');
 		expect(result).toContain('</x-build-status>');
+	});
+
+	test('renders build badges from the same-origin', async () => {
+		const container = await AstroContainer.create();
+		const result = await container.renderToString(BuildStatus);
+
+		expect(result).toContain('src="http://localhost/badges/test-status.svg"');
+		expect(result).toContain('src="http://localhost/badges/deploy-status.svg"');
+		expect(result).not.toContain('img.shields.io');
 	});
 });

--- a/src/components/Block/__tests__/GithubLink.spec.ts
+++ b/src/components/Block/__tests__/GithubLink.spec.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, test } from 'vitest';
+import GithubLink from '../GithubLink.astro';
+
+describe('GithubLink component', () => {
+	test('renders a link to the GitHub profile', async () => {
+		const container = await AstroContainer.create();
+		const result = await container.renderToString(GithubLink);
+
+		expect(result).toContain('<a');
+		expect(result).toContain('href="https://github.com/gibbs/"');
+		expect(result).toContain('target="_blank"');
+		expect(result).toContain('rel="noopener noreferrer"');
+	});
+
+	test('renders an accessible inline SVG icon', async () => {
+		const container = await AstroContainer.create();
+		const result = await container.renderToString(GithubLink);
+
+		expect(result).toContain('<svg');
+		expect(result).toContain('aria-hidden="true"');
+		expect(result).toContain('aria-label="View source on GitHub"');
+	});
+});

--- a/src/components/Block/__tests__/SchemePreference.spec.ts
+++ b/src/components/Block/__tests__/SchemePreference.spec.ts
@@ -12,4 +12,15 @@ describe('SchemePreference component', () => {
 		expect(result).toContain('aria-pressed="false"');
 		expect(result).toContain('Toggle colour scheme');
 	});
+
+	test('renders sun and moon icons instead of a switch', async () => {
+		const container = await AstroContainer.create();
+		const result = await container.renderToString(SchemePreference);
+
+		expect(result).toContain('x-show="!isDark"');
+		expect(result).toContain('x-show="isDark"');
+		expect((result.match(/<svg/g) || []).length).toBe(2);
+		expect(result).not.toContain('scheme-preference-switch');
+		expect(result).not.toContain('scheme-preference-slider');
+	});
 });

--- a/src/components/Layout/Header.astro
+++ b/src/components/Layout/Header.astro
@@ -1,4 +1,5 @@
 ---
+import GithubLink from '@components/Block/GithubLink.astro';
 import SchemePreference from '@components/Block/SchemePreference.astro';
 import Navigation from '@components/Layout/Navigation.astro';
 import SearchBar from '@components/Block/SearchBar.astro';
@@ -7,7 +8,10 @@ import SearchBar from '@components/Block/SearchBar.astro';
 <header class="header">
 	<Navigation />
 	<SearchBar />
-	<SchemePreference />
+	<div class="header-actions">
+		<GithubLink />
+		<SchemePreference />
+	</div>
 
 	<slot name="header" slot="header" />
 </header>

--- a/src/components/Meta/ContentSecurityPolicy.astro
+++ b/src/components/Meta/ContentSecurityPolicy.astro
@@ -37,11 +37,7 @@ const resources: CspDirectives = {
 		new URL('/', env.APP_SEARCH_URL).href,
 		'https://o4511127957929984.ingest.us.sentry.io',
 	].join(' '),
-	'img-src': [
-		'https://github.com/gibbs/',
-		'https://img.shields.io/',
-		'https://images.prismic.io/dangibbs/',
-	].join(' '),
+	'img-src': ['https://github.com/gibbs/', 'https://images.prismic.io/dangibbs/'].join(' '),
 	'script-src': ['https://static.cdn.prismic.io/'].join(' '),
 	'frame-src': ['https://dangibbs.prismic.io/'].join(' '),
 };

--- a/src/data/en-gb.i18n.ts
+++ b/src/data/en-gb.i18n.ts
@@ -13,6 +13,9 @@ const trans: Record<string, any> = {
 		},
 		copyright: `Copyright $1 2007 - $2 Dan Gibbs`,
 		build: 'Build',
+		github: {
+			label: 'View source on GitHub',
+		},
 		githubinsights: {
 			sourced: 'Data sourced from public repositories',
 		},

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -115,6 +115,7 @@ body {
 	}
 
 	.fieldset {
+		min-width: 0;
 		margin: var(--gap) 0;
 	}
 
@@ -130,12 +131,20 @@ body {
 		flex-direction: row;
 		align-items: center;
 		gap: var(--gap-xs);
+
+		input[type="checkbox"] {
+			flex-shrink: 0;
+		}
 	}
 
 	.form-checkbox-label {
 		font-weight: normal;
 		font-size: normal;
 		margin: var(--gap-xs) 0;
+	}
+
+	.form-checkbox-input {
+		flex-shrink: 0;
 	}
 
 	.form-helper {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -94,6 +94,13 @@ td, th {
 	z-index: 100;
 }
 
+.header-actions {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--gap);
+}
+
 .skip-link {
 	position: absolute;
 	top: var(--gap-sm);

--- a/src/styles/tool.css
+++ b/src/styles/tool.css
@@ -6,6 +6,8 @@
 	font-size: small;
 	border: 3px solid;
 	animation: result ease var(--transition-duration);
+	max-width: 100%;
+	overflow-x: auto;
 
 	pre {
 		margin: 0;


### PR DESCRIPTION
Performance and styling amends.

- Remove luxon from time component (unnecessary)
- Remove shields.io badges, move to images created at build time
- Remove scheme preference switcher and add github link to header
- Defer loading of meilisearch
- Remove Sentry replays (not used)
- Minor styling amendments to form and tool stylesheets 