### PR TITLE
fix: switch scheme preference icons for clarity

### DIFF
--- a/src/components/Block/SchemePreference.astro
+++ b/src/components/Block/SchemePreference.astro
@@ -13,7 +13,7 @@
 	@click="changeScheme"
 >
 	<svg
-		x-show="!isDark"
+		x-show="isDark"
 		width="24px"
 		height="24px"
 		viewBox="0 0 24 24"
@@ -26,7 +26,7 @@
 	</svg>
 
 	<svg
-		x-show="isDark"
+		x-show="!isDark"
 		width="24px"
 		height="24px"
 		viewBox="0 0 24 24"


### PR DESCRIPTION
Switch scheme preference icons